### PR TITLE
Updated package.json "main" entry to point to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
         "browserify": ">=1.1.0"
       , "uglify-js": "1.0.x"
     }
-  , "main": "gradient"
+  , "main": "./index.js"
   , "engines": [ "node >= 0.4"]
 }


### PR DESCRIPTION
The main entry of package.json was pointing to a non-existent file. This caused problems for me in browserify. I've updated package.json so that main points to the actual entry point.
